### PR TITLE
Solve Issue #1 | Logic changes for bad client requests for new safes / Refactored safe retention logic

### DIFF
--- a/plugins/modules/cyberark_safe.py
+++ b/plugins/modules/cyberark_safe.py
@@ -398,7 +398,8 @@ def main():
             location=dict(type="str"),
             managing_cpm=dict(type="str"),
             number_of_versions_retention=dict(type="int"),
-            number_of_days_retention=dict(type="int", default=7),
+            #HOTFIX: See issue #1 on Parent Repository.
+            number_of_days_retention=dict(type="int"),
             auto_purge_enabled=dict(type="bool", default=False),
             logging_level=dict(
                 type="str", choices=["NOTSET", "DEBUG", "INFO"]


### PR DESCRIPTION
### Desired Outcome
The Ansible module should NOT enforce a default value of 7 in the way that it currently does. Module should handle bad user requests that specify both versions and days. Module should still include the default, but only if versions is not already specified.

### Implemented Changes
I have removed the default argument of 7 Days for number_of_days_retention on line 401 of the cyberark_safe.py module in order to quickly resolve issue https://github.com/VOID1793/ansible-isp-collection-1.0.4-Hotfix/pull/1 with the parent. While I understand that the default argument brings the Ansible module's default behavior in line with the parent application, the implementation had the unintended consequence of forcing the creation of Days-based safes and preventing the creation of Versions-based safes.

Furthermore, logic has been revised to improve functionality and retain the default 7-day retention behavior. The module now handles bad client requests that include both parameters as well.

### Connected Issue/Story

Resolves #1

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [x] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes


**I am simply a user submitting a behavior change for consideration. I performed local testing with the API after the logic changes and was able to confirm that the new error-handling functions properly, and that the previous behavior regarding a default value of 7 days was retained and is functional. Furthermore, users may now specify versions OR days without unexpected behavior.**

Thank you!
